### PR TITLE
redux-todos: Allow for variable state slice name in Connector HOC

### DIFF
--- a/packages/redux-todos/src/Connector.jsx
+++ b/packages/redux-todos/src/Connector.jsx
@@ -1,7 +1,10 @@
 import { connect } from 'react-redux';
 import { actions } from './';
 
-const mapStateToProps = state => ({
-  todos: state.todos,
-});
-export default Component => connect(mapStateToProps, actions)(Component);
+const createMapStateToProps = stateSlice =>
+  state => ({
+    todos: state[stateSlice],
+  });
+
+export default stateSlice =>
+  Component => connect(createMapStateToProps(stateSlice), actions)(Component);


### PR DESCRIPTION
This allows for mounting the state slice managed by the reducer with an
arbitrary name, thus preventing name conflicts. The HOC can then be called
like:

    connectTodos('todos')(<DumbComponent />)