### PR TITLE
redux-todos: Move actions & constants to own file

### DIFF
--- a/packages/redux-todos/src/Connector.jsx
+++ b/packages/redux-todos/src/Connector.jsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { actions } from './';
+import actions from './actions';
 
 const mapStateToProps = state => ({
   todos: state.todos,

--- a/packages/redux-todos/src/actions.js
+++ b/packages/redux-todos/src/actions.js
@@ -1,0 +1,10 @@
+import { ADD_TODO } from './constants';
+
+export const addTodo = todo => ({
+  type: ADD_TODO,
+  todo,
+});
+
+export default {
+  addTodo,
+};

--- a/packages/redux-todos/src/constants.js
+++ b/packages/redux-todos/src/constants.js
@@ -1,0 +1,5 @@
+export const ADD_TODO = 'ADD_TODO';
+
+export default {
+  ADD_TODO,
+}

--- a/packages/redux-todos/src/index.js
+++ b/packages/redux-todos/src/index.js
@@ -1,20 +1,8 @@
+import { ADD_TODO } from './constants';
+export { default as actions } from './actions';
+export { default as constants } from './constants';
 export { default as connectTodos } from './Connector';
 export { default as PropTypes } from './PropTypes';
-
-export const ADD_TODO = 'ADD_TODO';
-
-export const addTodo = todo => ({
-  type: ADD_TODO,
-  todo,
-});
-
-export const types = {
-  ADD_TODO,
-};
-
-export const actions = {
-  addTodo,
-};
 
 export default (state = [], action) => {
   switch (action.type) {

--- a/packages/redux-todos/src/index.test.js
+++ b/packages/redux-todos/src/index.test.js
@@ -1,10 +1,12 @@
-import todos, { actions, types } from './';
+import reducer  from './';
+import constants from './constants';
+import actions from './actions';
 
 describe('actions', () => {
   it('should create an action to add a todo', () => {
     const todo = 'foo';
     const expectedAction = {
-      type: types.ADD_TODO,
+      type: constants.ADD_TODO,
       todo,
     };
     expect(actions.addTodo(todo)).toEqual(expectedAction);
@@ -14,8 +16,8 @@ describe('actions', () => {
 describe('reducer', () => {
   it('should add a todo', () => {
     const todo = 'a todo';
-    const state = todos(undefined, {});
-    const newState = todos(state, actions.addTodo(todo));
+    const state = reducer(undefined, {});
+    const newState = reducer(state, actions.addTodo(todo));
     const expectedState = [todo];
     expect(newState).toEqual(expectedState);
   });


### PR DESCRIPTION
Let's make sure we do not use problematic cyclic dependencies.